### PR TITLE
Implement persistent multi-GPU embedding workers

### DIFF
--- a/streamlit/rag_models.py
+++ b/streamlit/rag_models.py
@@ -1,6 +1,7 @@
 import os
 import multiprocessing as mp
 import numpy as np
+from typing import List, Tuple
 
 # Модели
 from sentence_transformers import SentenceTransformer
@@ -14,61 +15,111 @@ import stopwordsiso as stopwords
 import rag_core as rc
 
 
-def _chunk_iter(items: list[str], size: int) -> list[list[str]]:
-    """Разбиение списка на батчи фиксированного размера."""
-    return [items[i:i + size] for i in range(0, len(items), size)]
+_embed_in_queue: mp.Queue | None = None
+_embed_out_queue: mp.Queue | None = None
+_embed_workers: list[mp.Process] = []
+_embed_jobs_submitted: int = 0
 
 
-def _worker_encode(args):
-    """Воркер-процесс для мульти-GPU энкодинга эмбеддингов.
-
-    Параметры: (device_id, model_name, texts)
-    Возврат: np.ndarray float32 с L2-нормализацией на уровне модели.
-    """
-    device_id, model_name, texts = args
+def _embed_worker(device_id: int, model_name: str, max_length: int, in_q: mp.Queue, out_q: mp.Queue) -> None:
+    """Процесс-воркер, загружающий модель один раз на GPU."""
     os.environ["CUDA_VISIBLE_DEVICES"] = str(device_id)
-    from sentence_transformers import SentenceTransformer as _ST  # локальный импорт
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
     import torch  # type: ignore
 
+    torch.set_grad_enabled(False)
+    try:
+        torch.backends.cudnn.benchmark = True
+    except Exception:
+        pass
     torch.cuda.set_device(0)
+
+    from sentence_transformers import SentenceTransformer as _ST  # локальный импорт
     model = _ST(model_name, trust_remote_code=True, device="cuda")
-    emb = model.encode(
-        sentences=texts,
-        show_progress_bar=False,
-        convert_to_numpy=True,
-        normalize_embeddings=True,
-    ).astype("float32")
-    return emb
+    model.max_seq_length = int(max_length)
+    model.eval()
+
+    while True:
+        job = in_q.get()
+        if job is None:
+            break
+        start_idx, texts = job
+        with torch.inference_mode():
+            emb = model.encode(
+                sentences=texts,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,
+            ).astype("float32")
+        out_q.put((start_idx, emb))
+        torch.cuda.empty_cache()
+    del model
 
 
-def encode_multi_gpu(texts: list[str], batch_size: int, gpu_ids: list[int]) -> np.ndarray:
-    """Распределённое кодирование эмбеддингов по нескольким GPU."""
-    if not texts:
-        return np.zeros((0, 0), dtype="float32")
-    batches = _chunk_iter(texts, batch_size)
-    tasks = []
-    for i, b in enumerate(batches):
-        device_id = gpu_ids[i % len(gpu_ids)]
-        tasks.append((device_id, rc.EMBEDDING_MODEL_NAME, b))
-    from multiprocessing import Pool
-    with Pool(processes=min(len(tasks), len(gpu_ids))) as pool:
-        results = pool.map(_worker_encode, tasks)
-    return np.concatenate(results, axis=0)
+def start_embed_workers(devices: List[int], model_name: str, max_length: int, batch_size: int) -> None:
+    """Стартует воркеры энкодера на указанных GPU."""
+    global _embed_in_queue, _embed_out_queue, _embed_workers, _embed_jobs_submitted
+    _embed_in_queue = mp.Queue()
+    _embed_out_queue = mp.Queue()
+    _embed_workers = []
+    _embed_jobs_submitted = 0
+    for dev in devices:
+        p = mp.Process(target=_embed_worker, args=(dev, model_name, max_length, _embed_in_queue, _embed_out_queue))
+        p.daemon = True
+        p.start()
+        _embed_workers.append(p)
 
 
-def initialize_models() -> None:
+def submit_embed(job: Tuple[int, list[str]]) -> None:
+    """Отправляет задание на кодирование эмбеддингов."""
+    global _embed_jobs_submitted
+    if _embed_in_queue is None:
+        raise RuntimeError("Embed workers not started")
+    _embed_in_queue.put(job)
+    _embed_jobs_submitted += 1
+
+
+def drain_embed() -> list[Tuple[int, np.ndarray]]:
+    """Ожидает результаты всех отправленных задач."""
+    global _embed_jobs_submitted
+    results: list[Tuple[int, np.ndarray]] = []
+    if _embed_out_queue is None:
+        return results
+    for _ in range(_embed_jobs_submitted):
+        results.append(_embed_out_queue.get())
+    _embed_jobs_submitted = 0
+    return results
+
+
+def stop_embed_workers() -> None:
+    """Останавливает все воркеры энкодера."""
+    global _embed_in_queue, _embed_out_queue, _embed_workers
+    if _embed_in_queue is None:
+        return
+    for _ in _embed_workers:
+        _embed_in_queue.put(None)
+    for p in _embed_workers:
+        p.join()
+    _embed_in_queue.close()
+    _embed_out_queue.close()
+    _embed_in_queue = None
+    _embed_out_queue = None
+    _embed_workers = []
+
+
+def initialize_models(load_embedder: bool = True, load_reranker: bool = True) -> None:
     """Инициализация и кэширование моделей/инструментов в глобальном состоянии rc.*"""
-    if rc.embedder is None:
+    if load_embedder and rc.embedder is None:
         rc.embedder = SentenceTransformer(
             rc.EMBEDDING_MODEL_NAME,
             trust_remote_code=True,
-            device=f"cuda:{rc.EMBED_GPU_IDS[0]}",
+            device=rc.EMBED_DEVICES[0],
         )
-    if rc.reranker is None:
+    if load_reranker and rc.reranker is None:
         try:
             import torch  # type: ignore
             has_cuda = bool(getattr(torch.cuda, "is_available", lambda: False)())
-            device = f"cuda:{rc.RERANK_GPU_ID}" if has_cuda else "cuda:0"
+            device = rc.RERANK_DEVICE if has_cuda else "cuda:0"
             use_fp16 = has_cuda
         except Exception:
             device = "cuda:0"
@@ -105,3 +156,4 @@ def initialize_models() -> None:
             rc.en_stopwords = set(stopwords.stopwords('en'))
         except Exception:
             rc.en_stopwords = set()
+


### PR DESCRIPTION
## Summary
- add configurable device settings for embedding and reranker models
- introduce persistent embedding worker processes with start/submit/drain/stop API
- rewrite ingestion to use workers and memmap for multi-GPU embedding

## Testing
- `python -m py_compile streamlit/rag_core.py streamlit/rag_models.py streamlit/rag_ingestion.py streamlit/rag_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9a478f8f08329bdda081d32143895