### PR TITLE
Enable multi-GPU reranking and optional FAISS GPU sharding

### DIFF
--- a/streamlit/rag_config.py
+++ b/streamlit/rag_config.py
@@ -84,6 +84,9 @@ FAISS_CPU_THREADS = (
     else (int(_cpu_threads_env) if _cpu_threads_env is not None else mp.cpu_count())
 )
 
+# Использовать ли FAISS на GPU (IndexShards). По умолчанию выключено.
+FAISS_USE_GPU = os.getenv("RAG_FAISS_USE_GPU", "0") not in {"0", "false", "False"}
+
 
 # ---------------------------
 # Ретрива / фьюжн

--- a/streamlit/rag_ingestion.py
+++ b/streamlit/rag_ingestion.py
@@ -103,6 +103,10 @@ def build_and_load_knowledge_base(pdf_dir: str, index_dir: str, force_rebuild: b
         except Exception:
             pass
         try:
+            rc.faiss_index = rc.to_gpu_sharded(rc.faiss_index)
+        except Exception:
+            pass
+        try:
             if rc.FAISS_CPU_THREADS is not None:
                 faiss.omp_set_num_threads(int(rc.FAISS_CPU_THREADS))
         except Exception:
@@ -233,6 +237,10 @@ def build_and_load_knowledge_base(pdf_dir: str, index_dir: str, force_rebuild: b
     except Exception:
         pass
     faiss.write_index(rc.faiss_index, faiss_path)
+    try:
+        rc.faiss_index = rc.to_gpu_sharded(rc.faiss_index)
+    except Exception:
+        pass
 
     # BM25: токенизация с учётом языка
     texts_for_bm25: List[tuple[str, str | None]] = []

--- a/streamlit/rag_models.py
+++ b/streamlit/rag_models.py
@@ -2,10 +2,12 @@ import os
 import multiprocessing as mp
 import numpy as np
 from multiprocessing.queues import Queue as MPQueue
+from typing import Any
 
 # Модели
 from sentence_transformers import SentenceTransformer
 from FlagEmbedding import FlagReranker
+from concurrent.futures import ThreadPoolExecutor
 
 # Язык/токенизация
 from lingua import Language, LanguageDetectorBuilder
@@ -194,33 +196,71 @@ def encode_multi_gpu(texts: list[str], batch_size: int, gpu_ids: list[int]) -> n
     return out
 
 
-def initialize_models(load_embedder: bool = True, load_reranker: bool = True) -> None:
-    """Инициализация и кэширование моделей/инструментов в глобальном состоянии rc.*
+def _optimize_torch_for_ampere() -> None:
+    """Включает оптимизации TF32 и autotune cuDNN."""
+    try:
+        import torch
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        torch.set_float32_matmul_precision("high")
+        torch.backends.cudnn.benchmark = True
+    except Exception:
+        pass
 
-    Аргументы управляют отложенной загрузкой крупных моделей для экономии GPU-памяти
-    в режимах, где они не требуются (например, при построении индекса).
-    """
+
+def build_reranker_pools() -> list[tuple[FlagReranker, Any, str]]:
+    """Создаёт по процессу реранкера на каждый GPU из rc.RERANK_GPU_IDS."""
+    pools: list[tuple[FlagReranker, Any, str]] = []
+    devices = [f"cuda:{gid}" for gid in rc.RERANK_GPU_IDS]
+    for dev in devices:
+        rr = FlagReranker(rc.RERANKER_MODEL_NAME, use_fp16=True, device=dev)
+        pool = rr.start_multi_process_pool(target_devices=[dev])
+        pools.append((rr, pool, dev))
+    return pools
+
+
+def rerank_multi_gpu(query: str, docs: list[str], pools: list[tuple[FlagReranker, Any, str]]) -> list[float]:
+    """Параллельный реранк кандидатов на нескольких GPU."""
+    if not docs:
+        return []
+    shards = np.array_split(np.arange(len(docs)), len(pools))
+    results: list[list[float]] = []
+    with ThreadPoolExecutor(len(pools)) as ex:
+        futures = []
+        for (rr, pool, _), idx in zip(pools, shards):
+            futures.append(
+                ex.submit(
+                    rr.compute_score_multi_process,
+                    pool,
+                    [query] * len(idx),
+                    [docs[i] for i in idx],
+                    batch_size=rc.RERANK_BATCH_SIZE,
+                    max_length=rc.RERANK_MAX_LENGTH,
+                )
+            )
+        for f in futures:
+            results.append(f.result())
+    out = np.empty(len(docs), dtype=np.float32)
+    for idx, scores in zip(shards, results):
+        out[idx] = scores
+    return out.tolist()
+
+
+def initialize_models(load_embedder: bool = True, load_reranker: bool = True) -> None:
+    """Инициализация и кэширование моделей/инструментов в глобальном состоянии rc.*"""
+
+    _optimize_torch_for_ampere()
+
     if load_embedder and rc.embedder is None:
         rc.embedder = SentenceTransformer(
             rc.EMBEDDING_MODEL_NAME,
             trust_remote_code=True,
             device=f"cuda:{rc.EMBED_GPU_IDS[0]}",
         )
-    if load_reranker and rc.reranker is None:
-        try:
-            import torch  # type: ignore
-            has_cuda = bool(getattr(torch.cuda, "is_available", lambda: False)())
-            device = f"cuda:{rc.RERANK_GPU_ID}" if has_cuda else os.getenv("RAG_DEFAULT_CUDA_DEVICE", "cuda:0")
-            use_fp16 = has_cuda
-        except Exception:
-            device = os.getenv("RAG_DEFAULT_CUDA_DEVICE", "cuda:0")
-            use_fp16 = False
-        rc.reranker = FlagReranker(
-            rc.RERANKER_MODEL_NAME,
-            use_fp16=use_fp16,
-            max_length=rc.RERANK_MAX_LENGTH,
-            device=device,
-        )
+    if load_reranker and not rc.reranker_pools:
+        rc.reranker_pools = build_reranker_pools()
+        if rc.reranker_pools:
+            rc.reranker = rc.reranker_pools[0][0]
     if rc.language_detector is None:
         try:
             langs = [Language.RUSSIAN, Language.ENGLISH, Language.UKRAINIAN, Language.BELARUSIAN]


### PR DESCRIPTION
## Summary
- add optional FAISS GPU sharding switch
- enable Torch TF32 optimizations and multi-GPU reranking via process pools
- route pipeline reranking through new multi-GPU helper

## Testing
- `python -m py_compile streamlit/rag_config.py streamlit/rag_core.py streamlit/rag_ingestion.py streamlit/rag_models.py streamlit/rag_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68bae2feec708329a67e5a3ad330260f