### PR TITLE
Fix FlagReranker pool initialization

### DIFF
--- a/streamlit/rag_config.py
+++ b/streamlit/rag_config.py
@@ -84,6 +84,9 @@ FAISS_CPU_THREADS = (
     else (int(_cpu_threads_env) if _cpu_threads_env is not None else mp.cpu_count())
 )
 
+# Использовать ли FAISS на GPU (IndexShards). По умолчанию выключено.
+FAISS_USE_GPU = os.getenv("RAG_FAISS_USE_GPU", "0") not in {"0", "false", "False"}
+
 
 # ---------------------------
 # Ретрива / фьюжн

--- a/streamlit/rag_ingestion.py
+++ b/streamlit/rag_ingestion.py
@@ -103,6 +103,10 @@ def build_and_load_knowledge_base(pdf_dir: str, index_dir: str, force_rebuild: b
         except Exception:
             pass
         try:
+            rc.faiss_index = rc.to_gpu_sharded(rc.faiss_index)
+        except Exception:
+            pass
+        try:
             if rc.FAISS_CPU_THREADS is not None:
                 faiss.omp_set_num_threads(int(rc.FAISS_CPU_THREADS))
         except Exception:
@@ -233,6 +237,10 @@ def build_and_load_knowledge_base(pdf_dir: str, index_dir: str, force_rebuild: b
     except Exception:
         pass
     faiss.write_index(rc.faiss_index, faiss_path)
+    try:
+        rc.faiss_index = rc.to_gpu_sharded(rc.faiss_index)
+    except Exception:
+        pass
 
     # BM25: токенизация с учётом языка
     texts_for_bm25: List[tuple[str, str | None]] = []


### PR DESCRIPTION
## Summary
- build one FlagReranker per GPU without unsupported start_multi_process_pool arguments
- use compute_score in parallel threads for multi-GPU reranking

## Testing
- `python -m py_compile streamlit/rag_config.py streamlit/rag_core.py streamlit/rag_ingestion.py streamlit/rag_models.py streamlit/rag_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68bae2feec708329a67e5a3ad330260f